### PR TITLE
Remove breaking getDerivedStateFromProps in calendar

### DIFF
--- a/packages/calendar/src/Datepicker/Calender.js
+++ b/packages/calendar/src/Datepicker/Calender.js
@@ -8,19 +8,10 @@ import {nextItemInArray} from '../utils';
 class Calendar extends Component {
 
 	state = {
-		displayedPeriod: this.props.activeDate ? Moment(this.props.activeDate) : Moment(),
+		displayedPeriod: this.props.activeDate ? Moment(this.props.activeDate, this.props.format) : Moment(),
 		viewType: "days",
 		views: ["days", "months", "years"]
 	};
-
-	static getDerivedStateFromProps(nextProps, prevState) {
-		if (nextProps.activeDate !== '') {
-			return {
-				displayedPeriod: Moment(nextProps.activeDate, nextProps.format)
-			};
-		}
-		return null;
-	}
 
 	changeViewType() {
 		const {viewType, views} = this.state;


### PR DESCRIPTION
## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A changelog entry has been added to CHANGELOG.md if necessary

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] react application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->