### PR TITLE
Call onRequestClose when closing modal with 'x' button

### DIFF
--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -202,7 +202,7 @@ export default class Modal extends React.Component<Props, State> {
                   <h6>{title}</h6>
                 )}
                 {hasCloseButton && (
-                  <Button className="m-modal__close" icon="times" transparent onClick={() => this.handleToggleModal(false)} />
+                  <Button className="m-modal__close" icon="times" transparent onClick={() => this.handleRequestClose()} />
                 )}
               </div>
             )}


### PR DESCRIPTION
The onRequestClose callback is not called when the modal is clossed with the 'x' button in the upper right corner. This is a proposal to fix this behaviour.

## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A changelog entry has been added to CHANGELOG.md if necessary

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] react application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Modal is closed when clicking the 'x'-button without calling onRequestClose.
Issue Number: N/A

## What is the new behavior?
onRequestClose is called when closing the modal with the 'x'-button.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->