### PR TITLE
fix(autocomplete): added selection prop to prefill selection

### DIFF
--- a/packages/autocomplete/Readme.md
+++ b/packages/autocomplete/Readme.md
@@ -198,6 +198,35 @@ The prop `multipleSelect` can be used to allow multi selecting items.
 </Autocomplete>
 ```
 
+The prop `selection` can be used to show selected items when the component gets loaded.
+```
+<Autocomplete
+  items={[
+    { label: "Antwerpen", value: "antwerpen"},
+    { label: "Gent", value: "gent"},
+    { label: "Brussel", value: "brussel"},
+    { label: "Brugge", value: "brugge"},
+    { label: "Hasselt", value: "hasselt"},
+    { label: "Luik", value: "luik"},
+    { label: "Oostende", value: "oostende"},
+    { label: "Namen", value: "namen"},
+    { label: "Mechelen", value: "mechelen"},
+    { label: "Sint-Niklaas", value: "sint-niklaas"},
+    { label: "Aalst", value: "aalst"},
+    { label: "Genk", value: "genk"}
+  ]}
+  selection={[
+    { label: "Aalst", value: "aalst"},
+    { label: "Genk", value: "genk"}
+  ]}
+  id="autocomplete-2"
+  multipleSelect="true"
+  onSelection={(selected) => {console.log(`Selected ${selected}`)}}
+  onChange={(value) => {console.log(`Typed ${value}`)}}
+  label="Select a city">
+</Autocomplete>
+```
+
 The prop `asyncItems` can be used to lazy load the select items.
 ```
 const items=[

--- a/packages/autocomplete/src/component/Autocomplete.jsx
+++ b/packages/autocomplete/src/component/Autocomplete.jsx
@@ -28,6 +28,7 @@ type Props = {
   open?: boolean;
   label: string;
   id: string;
+  selection?: Array<Item>;
   defaultValue?: string;
   noResults?: string;
   onSelection?: (selection: Item | Array<Item>) => void;
@@ -58,7 +59,7 @@ class Autocomplete extends Component<Props, IState> {
     open: this.props.open || false,
     results: this.props.items || [],
     cursor: 0,
-    selection: [],
+    selection: this.props.selection || [],
     defaultValue: this.props.defaultValue || ''
   }
 

--- a/packages/autocomplete/src/component/Autocomplete.spec.js
+++ b/packages/autocomplete/src/component/Autocomplete.spec.js
@@ -51,8 +51,19 @@ describe('Autocomplete Test', () => {
     test('selecting item ', () => {
       component = new Autocomplete({});
       const spyOnSelect = sinon.stub(component.selectionMode, 'select');
-      component.selectOption({label: 'hi', value: 'hi'});
+      component.selectOption({ label: 'hi', value: 'hi' });
       expect(spyOnSelect.calledOnce).toBe(true);
+    })
+    test('should add selected item to already selected items passed by props', () => {
+      component = new Autocomplete({
+        multipleSelect: true,
+        selection: [{ label: 'hello', value: 'hello' }]
+      });
+      component.selectOption({ label: 'hi', value: 'hi' });
+      expect(component.state.selection).toEqual([
+        { label: 'hello', value: 'hello' },
+        { label: 'hi', value: 'hi' }
+      ]);
     })
   })
 });


### PR DESCRIPTION
## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A changelog entry has been added to CHANGELOG.md if necessary

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] react application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there is no possibility to pass an array of selected items when the component loads.
Issue Number: N/A

## What is the new behavior?
Added the possibility to pass an array of selected items when the component loads.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->