### PR TITLE
fix(pagination): also rerender when totalValues or itemsPerPage change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- `Pagination` Fixed Pagination not rerendering when `itemsPerPage` or `totalValues` change
 
 ## v4.7.0 - 05-10-2020
 

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -48,7 +48,11 @@ export default class Pagination extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.currentPage !== this.props.currentPage) {
+    if (
+      prevProps.currentPage !== this.props.currentPage ||
+      prevProps.itemsPerPage !== this.props.itemsPerPage ||
+      prevProps.totalValues !== this.props.totalValues
+    ) {
       this.setState(this.setValues);
     }
   }

--- a/packages/pagination/src/Pagination.spec.js
+++ b/packages/pagination/src/Pagination.spec.js
@@ -154,6 +154,22 @@ describe("Pagination", () => {
     expect(component.state().currentPage).toEqual(6);
   });
 
+  test("It should rerender when itemsPerPage changes", () => {
+    const component = mount(<Pagination itemsPerPage={6} totalValues={20} />);
+
+    expect(component.state().numbers).toHaveLength(4);
+    component.setProps({ itemsPerPage: 12 });
+    expect(component.state().numbers).toHaveLength(2);
+  });
+
+  test("It should rerender when totalValues changes", () => {
+    const component = mount(<Pagination itemsPerPage={8} totalValues={20} />);
+
+    expect(component.state().numbers).toHaveLength(3);
+    component.setProps({ totalValues: 6 });
+    expect(component.state().numbers).toHaveLength(1);
+  });
+
   test("should set the data-qa attribute", () => {
     const component = shallow(
       <Pagination qa="id-1234" itemsPerPage={4} totalValues={60} />


### PR DESCRIPTION
## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] A changelog entry has been added to CHANGELOG.md if necessary

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] react application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #176 

## What is the new behavior?

Pagination component will also rerender when `itemsPerPage` or `totalValues` change

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->