### PR TITLE
Avoid passing unexpected props to input element

### DIFF
--- a/packages/form/src/TextField/TextField.js
+++ b/packages/form/src/TextField/TextField.js
@@ -52,12 +52,12 @@ class TextField extends Component<Props> {
       disabled,
       iconright,
       iconleft,
+      loading,
       qa,
       type,
       errorDescription,
+      ...extraProps,
     } = this.props;
-
-    const {loading, ...extraProps} = this.props;
 
     const inputClass = classNames(
       'a-input',


### PR DESCRIPTION
## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A changelog entry has been added to CHANGELOG.md if necessary

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] react application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently all props, except from `loading` are passed on to the `<input>` element. This results in the following warning:

```
Warning: React does not recognize the `errorDescription` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `errordescription` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in input
          in div
          in div
```

Issue Number: N/A

## What is the new behavior?

Only the actual `extra props` are passed on to the <input> element

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This introduces a potential breaking change, since before it was possible to define a `type='email'` as a property that was then passed on to the `<input>` element. But, this was a bug on its own, since according to de docs the `type` can only be `small, normal, large`